### PR TITLE
feat(home): implement HomeScreen UI with task list and calendar row

### DIFF
--- a/lib/features/authentication/views/access_info_screen.dart
+++ b/lib/features/authentication/views/access_info_screen.dart
@@ -3,8 +3,8 @@ import 'package:daily_planner/constants/gaps.dart';
 import 'package:daily_planner/constants/sizes.dart';
 import 'package:go_router/go_router.dart';
 
-class WelcomeScreen extends StatelessWidget {
-  const WelcomeScreen({super.key});
+class AccessInfoScreen extends StatelessWidget {
+  const AccessInfoScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -26,9 +26,7 @@ class WelcomeScreen extends StatelessWidget {
           ),
         ),
         child: Padding(
-          padding: const EdgeInsets.symmetric(
-            horizontal: Sizes.size32,
-          ),
+          padding: const EdgeInsets.symmetric(horizontal: Sizes.size32),
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -49,15 +47,15 @@ class WelcomeScreen extends StatelessWidget {
               ),
               Gaps.v32,
               Text(
-                'Welcome to Daily Planner',
-                textAlign: TextAlign.center,
+                'Create an account to sync \nyour planner',
+                textAlign: TextAlign.left,
                 style: textTheme.headlineMedium?.copyWith(
                   color: Colors.white,
                 ),
               ),
               Gaps.v12,
               Text(
-                'Stay organized, manage your tasks, and plan every moment with ease.',
+                "Because planner is stored on your devices, you'll need to create an account to access your planner on another phone.",
                 textAlign: TextAlign.left,
                 style: textTheme.bodyMedium?.copyWith(
                   color: Colors.white70,
@@ -68,9 +66,9 @@ class WelcomeScreen extends StatelessWidget {
                 width: double.infinity,
                 child: ElevatedButton(
                   onPressed: () {
-                    context.go("/access");
+                    context.go("/createPlanner");
                   },
-                  child: const Text('Create a planner'),
+                  child: const Text('Skip for now'),
                 ),
               ),
               Gaps.v16,
@@ -78,7 +76,7 @@ class WelcomeScreen extends StatelessWidget {
                 width: double.infinity,
                 child: OutlinedButton(
                   onPressed: () {
-                    context.go("/login");
+                    context.go("/signup");
                   },
                   style: OutlinedButton.styleFrom(
                     foregroundColor: Colors.white,
@@ -86,7 +84,7 @@ class WelcomeScreen extends StatelessWidget {
                       color: Colors.white,
                     ),
                   ),
-                  child: const Text('Use my existing planner'),
+                  child: const Text('Create account'),
                 ),
               ),
             ],

--- a/lib/features/authentication/views/create_planner_screen.dart
+++ b/lib/features/authentication/views/create_planner_screen.dart
@@ -1,0 +1,58 @@
+import 'package:daily_planner/constants/gaps.dart';
+import 'package:daily_planner/constants/sizes.dart';
+import 'package:daily_planner/features/authentication/widgets/auth_button.dart';
+import 'package:daily_planner/features/authentication/widgets/auth_text_field.dart';
+import 'package:daily_planner/theme/text_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class CreatePlannerScreen extends StatefulWidget {
+  const CreatePlannerScreen({super.key});
+
+  @override
+  State<CreatePlannerScreen> createState() => _CreatePlannerScreenState();
+}
+
+class _CreatePlannerScreenState extends State<CreatePlannerScreen> {
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final color = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: Sizes.size20,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Gaps.v72,
+              Text(
+                'Name your planner',
+                style: textTheme.headlineMedium,
+              ),
+              Gaps.v32,
+              Text(
+                "Planner name",
+                style: textTheme.labelLarge,
+              ),
+              Gaps.v10,
+              const AuthTextField(
+                label: 'My Planner',
+              ),
+              Gaps.v32,
+              AuthButton(
+                label: 'Create a planner',
+                onPressed: () {
+                  context.go("/home");
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/authentication/views/login_screen.dart
+++ b/lib/features/authentication/views/login_screen.dart
@@ -3,6 +3,7 @@ import 'package:daily_planner/constants/sizes.dart';
 import 'package:daily_planner/features/authentication/widgets/auth_button.dart';
 import 'package:daily_planner/features/authentication/widgets/auth_text_field.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -77,7 +78,7 @@ class _LoginScreenState extends State<LoginScreen> {
                   Gaps.h8,
                   GestureDetector(
                     onTap: () {
-                      // TODO: Navigate to SignUpScreen
+                      context.go("/signup");
                     },
                     child: Text(
                       'Sign Up',

--- a/lib/features/authentication/views/sign_up_screen.dart
+++ b/lib/features/authentication/views/sign_up_screen.dart
@@ -4,6 +4,7 @@ import 'package:daily_planner/features/authentication/widgets/auth_button.dart';
 import 'package:daily_planner/features/authentication/widgets/auth_text_field.dart';
 import 'package:daily_planner/theme/text_theme.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class SignUpScreen extends StatefulWidget {
   const SignUpScreen({super.key});
@@ -64,7 +65,7 @@ class _SignUpScreenState extends State<SignUpScreen> {
                   Gaps.h8,
                   GestureDetector(
                     onTap: () {
-                      // TODO: Navigate to LoginScreen
+                      context.go("/login");
                     },
                     child: Text(
                       'Log In',

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -1,10 +1,118 @@
+import 'package:daily_planner/constants/gaps.dart';
+import 'package:daily_planner/constants/sizes.dart';
+import 'package:daily_planner/features/home/widgets/todo_card.dart';
+import 'package:daily_planner/features/home/widgets/week_date_row.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 class HomeScreen extends StatelessWidget {
-  const HomeScreen({super.key});
+  final String? plannerName;
+
+  const HomeScreen({
+    super.key,
+    required this.plannerName,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold();
+    final color = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final now = DateTime.now();
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          onPressed: () {
+            //TODO: 메뉴 열기
+          },
+          icon: const Icon(
+            Icons.menu,
+          ),
+        ),
+        title: Text(
+          plannerName ?? 'My Planner',
+          style: textTheme.headlineMedium,
+        ),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.only(right: Sizes.size16),
+            child: CircleAvatar(
+              backgroundColor: color.primary.withValues(alpha: 0.8),
+              radius: 18,
+            ),
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Column(
+              children: [
+                Gaps.v20,
+                const Padding(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: Sizes.size20,
+                  ),
+                  child: WeekDateRow(),
+                ),
+                Gaps.v20,
+              ],
+            ),
+            Expanded(
+              flex: 3,
+              child: Center(
+                child: Container(
+                  width: 260,
+                  height: 260,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: color.primary,
+                  ),
+                  child: Stack(
+                    children: [
+                      //TODO: 도트 추가
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            Gaps.v20,
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: Sizes.size20,
+              ),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  'Today\'s Tasks',
+                  style: textTheme.headlineMedium,
+                ),
+              ),
+            ),
+            Gaps.v12,
+            Expanded(
+              flex: 4,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: Sizes.size20),
+                child: ListView(
+                  children: [
+                    TodoCard(time: '[12:00 - 03:00]', text: 'Read a book'),
+                    TodoCard(time: '[03:00 - 05:00]', text: 'Workout'),
+                    TodoCard(time: '[05:00 - 06:00]', text: 'Write journal'),
+                  ],
+                ),
+              ),
+            )
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          //TODO: 할 일 추가
+        },
+        backgroundColor: color.primary,
+        child: const Icon(Icons.add),
+      ),
+    );
   }
 }

--- a/lib/features/home/widgets/todo_card.dart
+++ b/lib/features/home/widgets/todo_card.dart
@@ -1,0 +1,45 @@
+import 'package:daily_planner/constants/sizes.dart';
+import 'package:flutter/material.dart';
+
+class TodoCard extends StatelessWidget {
+  final String text;
+  final String time;
+
+  const TodoCard({
+    super.key,
+    required this.text,
+    required this.time,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return Card(
+      margin: const EdgeInsets.only(
+        bottom: Sizes.size12,
+      ),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(Sizes.size12),
+      ),
+      child: ListTile(
+        leading: const Icon(Icons.circle_outlined),
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              time,
+              style: textTheme.labelSmall?.copyWith(
+                color: Colors.grey,
+              ),
+            ),
+            Text(
+              text,
+              style: textTheme.bodyLarge,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/widgets/week_date_row.dart
+++ b/lib/features/home/widgets/week_date_row.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class WeekDateRow extends StatelessWidget {
+  const WeekDateRow({super.key});
+
+  List<DateTime> getWeekDates() {
+    final now = DateTime.now();
+    final todayWeekday = now.weekday;
+    final startOfWeek = now.subtract(Duration(days: todayWeekday - 1));
+
+    return List.generate(7, (i) => startOfWeek.add(Duration(days: i)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final dates = getWeekDates();
+    final now = DateTime.now();
+    final textTheme = Theme.of(context).textTheme;
+    final color = Theme.of(context).colorScheme;
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: dates.map((date) {
+        final isToday = DateUtils.isSameDay(date, now);
+        return Column(
+          children: [
+            Text(
+              '${date.day}',
+              style: textTheme.bodyLarge?.copyWith(
+                fontWeight: isToday ? FontWeight.bold : FontWeight.normal,
+                color: isToday ? color.primary : null,
+              ),
+            ),
+            Text(
+              DateFormat('EEE').format(date).toUpperCase(),
+              style: textTheme.labelSmall?.copyWith(
+                fontWeight: isToday ? FontWeight.bold : FontWeight.normal,
+                color: isToday ? color.primary : null,
+                letterSpacing: 1.5,
+              ),
+            ),
+          ],
+        );
+      }).toList(),
+    );
+  }
+}


### PR DESCRIPTION
### Summary
- Added new widgets:
  - `todo_card.dart`
  - `week_date_row.dart`
- 홈 화면 기본 레이아웃 구현 완료:
  - 주간 날짜 행 표시
  - 오늘의 할 일 리스트 UI 구성
  - 중앙 원형 영역
  
### Notes
- No functionality yet
- 기능 구현은 이후 추가 예정